### PR TITLE
Use redis tx and redis watch to handle race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ Implementation criteria:
 
 ## TODO
 - setup Nginx + load balancing
-- use transactions for limiting request rate using redis
 - perform authentication on endpoints
 - write unit tests
 - TODOs in the codebase
-- improve env var handling
 - remove .properties files and read from env
 - graceful stopping consumers

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,0 +1,86 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:6.2-alpine
+    restart: always
+    hostname: redis
+    container_name: redis
+    ports:
+      - '6379:6379'
+    command: redis-server --save 20 1 --loglevel warning
+    volumes: 
+      - cache:/data
+
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.3.2
+    hostname: zoo1
+    container_name: zoo1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka1
+    container_name: kafka1
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+      - "9999:9999"
+    expose:
+      - "9092"
+      - "29092"
+      - "19092"
+      - "9999"
+    environment:
+      # KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,DOCKER://host.docker.internal:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: ${DOCKER_HOST_IP:-127.0.0.1}
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+
+  producer:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    container_name: producer
+    ports:
+      - "8080:8080"
+    environment:
+      MODE: "producer"
+      MAX_REQ_PER_WINDOW: 5
+      WINDOW_LENGTH_IN_MINUTES: 3
+    depends_on:
+      - kafka1
+      - redis
+
+  consumer:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    container_name: consumer
+    environment:
+      MODE: "consumer"
+      MAX_REQ_PER_WINDOW: 5
+      WINDOW_LENGTH_IN_MINUTES: 3
+    depends_on:
+      - kafka1
+      - redis
+
+volumes:
+  cache:
+    driver: local


### PR DESCRIPTION
Two instances of the producer can concurrently increase the number of requests.
To solve the issue, used atomic increment using Redis Tx and Watch command.